### PR TITLE
Accept open files in wellmap.load()

### DIFF
--- a/tests/test_config_from_toml.py
+++ b/tests/test_config_from_toml.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import io
+from textwrap import dedent
+
 import pytest
 
 from wellmap import *
@@ -61,4 +64,10 @@ def test_config_from_toml(files, kwargs, config, concats, extras, deps, alerts, 
             assert actual_alerts == alerts
 
 
-
+def test_config_from_toml_from_file():
+    f = io.StringIO(dedent("""\
+        [well.A1]
+        x = 2
+        """))
+    config, _paths, _concats, _extras, _deps = config_from_toml(f)
+    assert config["well"]["A1"]["x"] == 2

--- a/wellmap/file.py
+++ b/wellmap/file.py
@@ -39,9 +39,10 @@ def load(toml_path, *, data_loader=None, merge_cols=None, path_guess=None,
     (which is the most typical use-case), that data frame will also contain 
     columns for any data associated with each well.
 
-    :param str,pathlib.Path toml_path:
-        The path to a file describing the layout of one or more plates.  See 
-        the :doc:`/file_format` page for details about this file.
+    :param str,pathlib.Path,IO[str] toml_path:
+        The path to a file describing the layout of one or more plates,
+        or a handle to an open file.
+        See the :doc:`/file_format` page for details about this file.
 
     :param callable data_loader:
         Indicates that `load()` should attempt to load the actual data 
@@ -322,13 +323,23 @@ def config_from_toml(toml_path, *, shift=(0,0), path_guess=None, path_required=F
     This function is mostly responsible for interpreting the various [meta] 
     settings.
     """
-    toml_path = Path(toml_path).resolve()
-    config = configdict(
-            shift_config(
-                toml.load(str(toml_path)),
-                shift,
-            ),
-    )
+    if hasattr(toml_path, "read"):
+        config = configdict(
+                shift_config(
+                    toml.load(toml_path),
+                    shift,
+                ),
+        )        
+        toml_path = Path().resolve() / "fake.toml"
+    else:
+        toml_path = Path(toml_path).resolve()
+        config = configdict(
+                shift_config(
+                    toml.load(str(toml_path)),
+                    shift,
+                ),
+        )
+
     concats = []
     deps = {toml_path}
 


### PR DESCRIPTION
This adds flexibility in general but also makes it possible to use wellmap with StringIO in order to embed short plate descriptions in unit tests, to be expanded by wellmap.