### PR TITLE
Guess_path can accept extension. This fixes the problem when loading …

### DIFF
--- a/wellmap/file.py
+++ b/wellmap/file.py
@@ -113,6 +113,7 @@ def load(toml_path, *, data_loader=None, merge_cols=None, path_guess=None,
         TOML file.  In code, that would be: 
         ``path_guess.format(Path(toml_path))``.  A typical value would be 
         something like ``'{0.stem}.csv'``.
+        Can also just contain an extension, e.g. '.csv'. In this case toml_path.stem+extension will be guessed.
 
     :param bool path_required:
         Indicates whether or not the given TOML file must reference one or more 
@@ -307,7 +308,6 @@ def load(toml_path, *, data_loader=None, merge_cols=None, path_guess=None,
                     'right_on': ['path'] + check_merge_cols(
                         merge_cols.values(), data.columns, 'values'),
             }
-
         merged = pd.merge(layout, data, **kwargs)
         return augment_return_value(merged)
 
@@ -697,7 +697,7 @@ class PathManager:
         self.path = path
         self.paths = paths
         self.toml_path = Path(toml_path)
-        self.path_guess = path_guess
+        self.path_guess = self.toml_path.stem+path_guess if path_guess is not None and path_guess[0]=='.' else path_guess  # extension or full name specified
         self.missing_path_error = None
 
     def __str__(self):


### PR DESCRIPTION
…multiple toml files from a main toml file (concat).

Example: main.toml:
```
[meta.concat]
'5h' = '20220901_nluc_AAV9.AB_B22_5h.toml'
'1h' = '20220901_nluc_AAV9.AB_B22_1h.toml'
```
20220901_nluc_AAV9.AB_B22_5h.toml contains well map, without specifying file name. Using the new code you can just write:
```py
def import_plate(toml_path: Path, data_extension: str = '.xlsx'):
    layout, data = wellmap.load(toml_path, data_loader=load_lum, path_guess=data_extension)
    data['well'] = data['row'] + data['col'].astype(str)
    df1 = pd.merge(layout, data, on=['well', 'path'])
```
This solution is economical in the sense that `20220901_nluc_AAV9.AB_B22_5h.toml` and `20220901_nluc_AAV9.AB_B22_5h.xlsx` having the same name, file names are only listed once.